### PR TITLE
Use `includes` instead of `system_includes` for `includes` attr

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -61,7 +61,7 @@ if [[ $PLATFORM == "darwin" ]] && \
 fi
 
 if [[ $PLATFORM == "windows" ]]; then
-  EXTRA_BAZEL_ARGS="${EXTRA_BAZEL_ARGS-} --cxxopt=/std:c++17 --host_cxxopt=/std:c++17"
+  EXTRA_BAZEL_ARGS="${EXTRA_BAZEL_ARGS-} --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --copt=/external:W0 --host_copt=/external:W0"
 fi
 
 source scripts/bootstrap/bootstrap.sh

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -44,6 +44,7 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --enable_bzlmod \
       --check_direct_dependencies=error \
       --lockfile_mode=update \
+      --features=external_include_paths --host_features=external_include_paths \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --java_runtime_version=${JAVA_VERSION} \
       --java_language_version=${JAVA_VERSION} \

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1133,7 +1133,10 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
 
   private Iterable<PathFragment> getValidationIgnoredDirs() {
     List<PathFragment> cxxSystemIncludeDirs = getBuiltInIncludeDirectories();
-    return Iterables.concat(cxxSystemIncludeDirs, ccCompilationContext.getSystemIncludeDirs());
+    return Iterables.concat(
+        cxxSystemIncludeDirs,
+        ccCompilationContext.getSystemIncludeDirs(),
+        ccCompilationContext.getExternalIncludeDirs());
   }
 
   @VisibleForTesting

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -510,7 +510,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         cxx_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "cxxopts"),
         defines = cc_helper.defines(ctx, additional_make_variable_substitutions),
         local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx, ctx.attr.deps),
-        system_includes = cc_helper.system_include_dirs(ctx, additional_make_variable_substitutions),
+        includes = cc_helper.include_dirs(ctx, additional_make_variable_substitutions),
         private_hdrs = cc_helper.get_private_hdrs(ctx),
         public_hdrs = cc_helper.get_public_hdrs(ctx),
         copts_filter = cc_helper.copts_filter(ctx, additional_make_variable_substitutions),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -1062,7 +1062,7 @@ def _package_source_root(repository, package, sibling_repository_layout):
         repository = repository[1:]
     return paths.get_relative(paths.get_relative("external", repository), package)
 
-def _system_include_dirs(ctx, additional_make_variable_substitutions):
+def _include_dirs(ctx, additional_make_variable_substitutions):
     result = []
     sibling_repository_layout = ctx.configuration.is_sibling_repository_layout()
     package = ctx.label.package
@@ -1264,7 +1264,8 @@ cc_helper = struct(
     get_private_hdrs = _get_private_hdrs,
     get_public_hdrs = _get_public_hdrs,
     report_invalid_options = _report_invalid_options,
-    system_include_dirs = _system_include_dirs,
+    include_dirs = _include_dirs,
+    system_include_dirs = _include_dirs,  # TODO: Remove uses of old name
     get_coverage_environment = _get_coverage_environment,
     create_cc_instrumented_files_info = _create_cc_instrumented_files_info,
     linkopts = _linkopts,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -63,7 +63,7 @@ def _cc_library_impl(ctx):
         cxx_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "cxxopts"),
         defines = cc_helper.defines(ctx, additional_make_variable_substitutions),
         local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx, ctx.attr.deps + ctx.attr.implementation_deps),
-        system_includes = cc_helper.system_include_dirs(ctx, additional_make_variable_substitutions),
+        includes = cc_helper.include_dirs(ctx, additional_make_variable_substitutions),
         copts_filter = cc_helper.copts_filter(ctx, additional_make_variable_substitutions),
         purpose = "cc_library-compile",
         srcs = cc_helper.get_srcs(ctx),

--- a/src/main/starlark/builtins_bzl/common/cc/compile/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/compile/cc_compilation_helper.bzl
@@ -227,7 +227,10 @@ def _init_cc_compilation_context(
     external_include_dirs = []
     declared_include_srcs = []
 
-    if not external:
+    if not external and feature_configuration.is_requested("system_include_paths"):
+        system_include_dirs_for_context = system_include_dirs + include_dirs
+        include_dirs_for_context = []
+    elif not external:
         system_include_dirs_for_context = list(system_include_dirs)
         include_dirs_for_context = list(include_dirs)
     else:

--- a/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl
@@ -105,7 +105,7 @@ def _build_common_variables(
         has_module_map = has_module_map,
         attr_linkopts = attr_linkopts,
         direct_cc_compilation_contexts = direct_cc_compilation_contexts,
-        includes = cc_helper.system_include_dirs(ctx, {}) if hasattr(ctx.attr, "includes") else [],
+        includes = cc_helper.include_dirs(ctx, {}) if hasattr(ctx.attr, "includes") else [],
     )
 
     return struct(

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -1196,18 +1196,12 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     assertContainsSublist(
         action.getCompilerOptions(),
         ImmutableList.of(
-            "-isystem",
-            "foo/foo",
-            "-isystem",
-            genfilesDir + "/foo/foo",
-            "-isystem",
-            binDir + "/foo/foo",
-            "-isystem",
-            "foo/bar",
-            "-isystem",
-            genfilesDir + "/foo/bar",
-            "-isystem",
-            binDir + "/foo/bar"));
+            "-Ifoo/foo",
+            "-I" + genfilesDir + "/foo/foo",
+            "-I" + binDir + "/foo/foo",
+            "-Ifoo/bar",
+            "-I" + genfilesDir + "/foo/bar",
+            "-I" + binDir + "/foo/bar"));
   }
 
   @Test
@@ -1911,10 +1905,12 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     assertThat(artifactsToStrings(libCompilationContext.getDeclaredIncludeSrcs()))
         .doesNotContain("src foo/implementation_dep.h");
 
-    assertThat(pathfragmentsToStrings(libCompilationContext.getSystemIncludeDirs()))
+    assertThat(pathfragmentsToStrings(libCompilationContext.getIncludeDirs()))
         .contains("foo/public_dep");
-    assertThat(pathfragmentsToStrings(libCompilationContext.getSystemIncludeDirs()))
+    assertThat(pathfragmentsToStrings(libCompilationContext.getIncludeDirs()))
         .contains("foo/interface_dep");
+    assertThat(pathfragmentsToStrings(libCompilationContext.getIncludeDirs()))
+        .doesNotContain("foo/implementation_dep");
     assertThat(pathfragmentsToStrings(libCompilationContext.getSystemIncludeDirs()))
         .doesNotContain("foo/implementation_dep");
 
@@ -1922,11 +1918,11 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
         getCppCompileAction("//foo:public_dep").getCcCompilationContext();
     assertThat(artifactsToStrings(publicDepCompilationContext.getDeclaredIncludeSrcs()))
         .contains("src foo/interface_dep.h");
-    assertThat(pathfragmentsToStrings(publicDepCompilationContext.getSystemIncludeDirs()))
+    assertThat(pathfragmentsToStrings(publicDepCompilationContext.getIncludeDirs()))
         .contains("foo/interface_dep");
     assertThat(artifactsToStrings(publicDepCompilationContext.getDeclaredIncludeSrcs()))
         .contains("src foo/implementation_dep.h");
-    assertThat(pathfragmentsToStrings(publicDepCompilationContext.getSystemIncludeDirs()))
+    assertThat(pathfragmentsToStrings(publicDepCompilationContext.getIncludeDirs()))
         .contains("foo/implementation_dep");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -1398,11 +1398,11 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
 
     List<String> mergedSystemIncludes =
         ((Depset) myInfo.getValue("merged_system_includes")).getSet(String.class).toList();
-    assertThat(mergedSystemIncludes).containsAtLeast("foo/bar", "a/dep1/baz", "a/dep2/qux");
+    assertThat(mergedSystemIncludes).contains("foo/bar");
 
     List<String> mergedIncludes =
         ((Depset) myInfo.getValue("merged_includes")).getSet(String.class).toList();
-    assertThat(mergedIncludes).contains("baz/qux");
+    assertThat(mergedIncludes).containsAtLeast("baz/qux", "a/dep1/baz", "a/dep2/qux");
 
     List<String> mergedQuoteIncludes =
         ((Depset) myInfo.getValue("merged_quote_includes")).getSet(String.class).toList();

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -1397,7 +1397,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
             Iterables.concat(
                 Iterables.transform(
                     rootedIncludePaths("package/foo/bar"),
-                    element -> ImmutableList.of("-isystem", element)))));
+                    element -> ImmutableList.of("-I" + element)))));
   }
 
   @Test


### PR DESCRIPTION
Previously even though the attribute was named `includes` it was passed
through the `system_includes` field of the compilation context. This
resulted in toolchains passing these include paths with `-isystem`,
which is unexpected if you use this for first party code.

Many non bazel-first projects have header directory structures that
require custom include paths be propagated throughout the graph, the
alternative to `includes` is to use `strip_include_prefix`. The downside
of `strip_include_prefix` is that you add 1 include path per
`cc_library`, even if the libraries are in the same package. With
`includes` these are deduplicated. In the case of LLVM using `includes`
reduced the number of search paths on the order of hundreds.

If users want to use `-isystem` for third party code that uses
`includes`, they can pass `--features=external_include_paths --host_features=external_include_paths`

If there are first party libraries users want to use `-isystem` with,
they can use `features = ["system_include_paths"]`

Fixes https://github.com/bazelbuild/bazel/issues/20267

RELNOTES[INC]: Use `-I` instead of `-isystem` for `cc_library` / `cc_binary` `includes` attr. To use `-isystem` for only external repositories, you can pass `--features=external_include_paths --host_features=external_include_paths`. To use `-isystem` for a single `cc_library` / `cc_binary` `includes`, you can set `features = ["system_include_paths"],` on the target


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for specifying general include directories in C++ and Objective-C build rules.
  - Added new build flags to improve handling of external include paths during the build process.

- **Bug Fixes**
  - Improved validation to correctly ignore external include directories during compilation.

- **Tests**
  - Updated and added tests to verify correct handling and propagation of include directories and related compiler flags.

- **Chores**
  - Updated internal scripts to pass new build options for enhanced compatibility and warning control on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->