### PR TITLE
Introduce flags to allow filtering of targets by rule name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -381,6 +381,29 @@ public final class TargetUtils {
     };
   }
 
+    /**
+   * Returns a predicate to be used for test rule name filtering, i.e., that only accepts tests that match
+   * a required rule name and not an excluded rule name.
+   */
+  public static Predicate<Target> ruleFilter(List<String> ruleFilterList) {
+    Pair<Collection<String>, Collection<String>> ruleLists =
+        TestTargetUtils.sortTagsBySense(ruleFilterList);
+    final Collection<String> requiredRules = ruleLists.first;
+    final Collection<String> excludedRules = ruleLists.second;
+    return input -> {
+      if (requiredRules.isEmpty() && excludedRules.isEmpty()) {
+        return true;
+      }
+
+      if (!(input instanceof Rule)) {
+        return requiredRules.isEmpty();
+      }
+
+      return TestTargetUtils.testMatchesRuleFilters(
+          ((Rule) input).getRuleClass(), requiredRules, excludedRules);
+    };
+  }
+
   /** Return {@link Location} for {@link Target} target, if it should not be null. */
   @Nullable
   public static Location getLocationMaybe(Target target) {

--- a/src/main/java/com/google/devtools/build/lib/packages/TestTargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TestTargetUtils.java
@@ -92,6 +92,18 @@ public final class TestTargetUtils {
   }
 
   /**
+   * Returns whether a test with a rule name matches a filter (as specified by the set
+   * of its positive and its negative filters).
+   */
+  public static boolean testMatchesRuleFilters(
+      String ruleName,
+      Collection<String> requiredRules,
+      Collection<String> excludedRules) {
+    return (requiredRules.isEmpty() || requiredRules.contains(ruleName)) &&
+            !excludedRules.contains(ruleName);
+  }
+
+  /**
    * Filters 'tests' (by mutation) according to the 'tags' attribute, specifically those that
    * match ALL of the tags in tagsAttribute.
    *

--- a/src/main/java/com/google/devtools/build/lib/pkgcache/LoadingOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/pkgcache/LoadingOptions.java
@@ -129,6 +129,35 @@ public class LoadingOptions extends OptionsBase {
   public List<String> testLangFilterList;
 
   @Option(
+    name = "build_rule_filters",
+    converter = CommaSeparatedOptionListConverter.class,
+    defaultValue = "",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help =
+        "Specifies a comma-separated list of rule names. Each rule name can be optionally "
+            + "preceded with '-' to specify excluded rule names. Only those targets will be built that "
+            + "equal the positive rule name or do not equal the negative rule name. This option "
+            + "does not affect the set of tests executed with the 'test' command; those are be "
+            + "governed by the test filtering options, for example '--test_rule_filters'"
+  )
+  public List<String> buildRuleFilterList;
+
+  @Option(
+    name = "test_rule_filters",
+    converter = CommaSeparatedOptionListConverter.class,
+    defaultValue = "",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help =
+      "Specifies a comma-separated list of rule names. Each rule name can be optionally "
+      + "preceded with '-' to specify excluded rule names. Only those test targets will be "
+      + "found that equal the positive rule name or do not equal the negative rule name."
+      + "This option affects --build_tests_only behavior and the test command."
+  )
+  public List<String> testRuleFilterList;
+
+  @Option(
     name = "build_manual_tests",
     defaultValue = "false",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3002,6 +3002,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
             options.buildTestsOnly,
             determineTests,
             ImmutableList.copyOf(options.buildTagFilterList),
+            ImmutableList.copyOf(options.buildRuleFilterList),
             options.buildManualTests,
             options.expandTestSuites,
             TestFilter.forOptions(options));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseFunction.java
@@ -367,8 +367,10 @@ final class TargetPatternPhaseFunction implements SkyFunction {
       }
     }
 
-    ResolvedTargets<Target> result =
-        builder.filter(TargetUtils.tagFilter(options.getBuildTargetFilter())).build();
+    builder.filter(TargetUtils.tagFilter(options.getBuildTargetFilter()));
+    builder.filter(TargetUtils.ruleFilter(options.getBuildRuleFilter()));
+
+    ResolvedTargets<Target> result = builder.build();
     if (options.getCompileOneDependency()) {
       EnvironmentBackedRecursivePackageProvider environmentBackedRecursivePackageProvider =
           new EnvironmentBackedRecursivePackageProvider(env);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseValue.java
@@ -155,6 +155,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
       boolean buildTestsOnly,
       boolean determineTests,
       ImmutableList<String> buildTargetFilter,
+      ImmutableList<String> buildRuleFilter,
       boolean buildManualTests,
       boolean expandTestSuites,
       @Nullable TestFilter testFilter) {
@@ -165,6 +166,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
         buildTestsOnly,
         determineTests,
         buildTargetFilter,
+        buildRuleFilter,
         buildManualTests,
         expandTestSuites,
         testFilter);
@@ -181,7 +183,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
   public static SkyKey keyWithoutFilters(
       ImmutableList<String> targetPatterns, PathFragment offset) {
     return new TargetPatternPhaseKey(
-        targetPatterns, offset, false, false, false, ImmutableList.of(), false, false, null);
+        targetPatterns, offset, false, false, false, ImmutableList.of(), ImmutableList.of(), false, false, null);
   }
 
   /** The configuration needed to run the target pattern evaluation phase. */
@@ -194,6 +196,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
     private final boolean buildTestsOnly;
     private final boolean determineTests;
     private final ImmutableList<String> buildTargetFilter;
+    private final ImmutableList<String> buildRuleFilter;
     private final boolean buildManualTests;
     private final boolean expandTestSuites;
     @Nullable private final TestFilter testFilter;
@@ -205,6 +208,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
         boolean buildTestsOnly,
         boolean determineTests,
         ImmutableList<String> buildTargetFilter,
+        ImmutableList<String> buildRuleFilter,
         boolean buildManualTests,
         boolean expandTestSuites,
         @Nullable TestFilter testFilter) {
@@ -214,6 +218,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
       this.buildTestsOnly = buildTestsOnly;
       this.determineTests = determineTests;
       this.buildTargetFilter = Preconditions.checkNotNull(buildTargetFilter);
+      this.buildRuleFilter = Preconditions.checkNotNull(buildRuleFilter);
       this.buildManualTests = buildManualTests;
       this.expandTestSuites = expandTestSuites;
       this.testFilter = testFilter;
@@ -249,6 +254,10 @@ public final class TargetPatternPhaseValue implements SkyValue {
 
     public ImmutableList<String> getBuildTargetFilter() {
       return buildTargetFilter;
+    }
+
+    public ImmutableList<String> getBuildRuleFilter() {
+      return buildRuleFilter;
     }
 
     public boolean getBuildManualTests() {
@@ -305,6 +314,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
           && other.buildTestsOnly == buildTestsOnly
           && other.determineTests == determineTests
           && other.buildTargetFilter.equals(buildTargetFilter)
+          && other.buildRuleFilter.equals(buildRuleFilter)
           && other.buildManualTests == buildManualTests
           && other.expandTestSuites == expandTestSuites
           && Objects.equals(other.testFilter, testFilter);

--- a/src/test/java/com/google/devtools/build/lib/packages/TestTargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TestTargetUtilsTest.java
@@ -118,6 +118,34 @@ public final class TestTargetUtilsTest extends PackageLoadingTestCase {
   public void testFilterByLang() {
     LoadingOptions options = new LoadingOptions();
     options.testLangFilterList = ImmutableList.of("positive", "-negative");
+    options.testRuleFilterList = ImmutableList.of();
+    options.testSizeFilterSet = ImmutableSet.of();
+    options.testTimeoutFilterSet = ImmutableSet.of();
+    options.testTagFilterList = ImmutableList.of();
+    TestFilter filter = TestFilter.forOptions(options);
+    Package pkg = mock(Package.class);
+    RuleClass ruleClass = mock(RuleClass.class);
+    when(ruleClass.getDefaultImplicitOutputsFunction())
+        .thenReturn(SafeImplicitOutputsFunction.NONE);
+    when(ruleClass.getAttributeProvider()).thenReturn(mock(AttributeProvider.class));
+    Rule mockRule =
+        new Rule(
+            pkg,
+            Label.parseCanonicalUnchecked("//pkg:a"),
+            ruleClass,
+            Location.fromFile(""),
+            /* interiorCallStack= */ null);
+    when(ruleClass.getName()).thenReturn("positive_test");
+    assertThat(filter.apply(mockRule)).isTrue();
+    when(ruleClass.getName()).thenReturn("negative_test");
+    assertThat(filter.apply(mockRule)).isFalse();
+  }
+
+  @Test
+  public void testFilterByRule() {
+    LoadingOptions options = new LoadingOptions();
+    options.testLangFilterList = ImmutableList.of();
+    options.testRuleFilterList = ImmutableList.of("positive_test", "-negative_test");
     options.testSizeFilterSet = ImmutableSet.of();
     options.testTimeoutFilterSet = ImmutableSet.of();
     options.testTagFilterList = ImmutableList.of();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseKeyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseKeyTest.java
@@ -53,6 +53,7 @@ public final class TargetPatternPhaseKeyTest {
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
                 ImmutableList.of(),
+                ImmutableList.of(),
                 false,
                 true,
                 null,
@@ -62,6 +63,7 @@ public final class TargetPatternPhaseKeyTest {
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
                 ImmutableList.of(),
+                ImmutableList.of(),
                 false,
                 false,
                 null,
@@ -70,6 +72,7 @@ public final class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
+                ImmutableList.of(),
                 ImmutableList.of(),
                 true,
                 true,
@@ -80,6 +83,7 @@ public final class TargetPatternPhaseKeyTest {
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
                 ImmutableList.of(),
+                ImmutableList.of(),
                 true,
                 false,
                 null,
@@ -88,6 +92,7 @@ public final class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
+                ImmutableList.of(),
                 ImmutableList.of(),
                 false,
                 true,
@@ -98,6 +103,7 @@ public final class TargetPatternPhaseKeyTest {
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
                 ImmutableList.of(),
+                ImmutableList.of(),
                 true,
                 true,
                 emptyTestFilter(),
@@ -106,6 +112,7 @@ public final class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
+                ImmutableList.of(),
                 ImmutableList.of(),
                 false,
                 true,
@@ -115,6 +122,7 @@ public final class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
+                ImmutableList.of(),
                 ImmutableList.of(),
                 true,
                 true,
@@ -125,6 +133,7 @@ public final class TargetPatternPhaseKeyTest {
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
                 ImmutableList.of("a"),
+                ImmutableList.of("a"),
                 false,
                 true,
                 null))
@@ -132,6 +141,7 @@ public final class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
+                ImmutableList.of("a"),
                 ImmutableList.of("a"),
                 true,
                 true,
@@ -143,6 +153,7 @@ public final class TargetPatternPhaseKeyTest {
       ImmutableList<String> targetPatterns,
       PathFragment offset,
       ImmutableList<String> buildTagFilter,
+      ImmutableList<String> buildRuleFilter,
       boolean includeManualTests,
       boolean expandTestSuites,
       @Nullable TestFilter testFilter,
@@ -158,6 +169,7 @@ public final class TargetPatternPhaseKeyTest {
         buildTestsOnly,
         determineTests,
         buildTagFilter,
+        buildRuleFilter,
         includeManualTests,
         expandTestSuites,
         testFilter);
@@ -165,7 +177,7 @@ public final class TargetPatternPhaseKeyTest {
 
   private static TargetPatternPhaseKey of(
       ImmutableList<String> targetPatterns, PathFragment offset) {
-    return of(targetPatterns, offset, ImmutableList.of(), false, true, null);
+    return of(targetPatterns, offset, ImmutableList.of(), ImmutableList.of(), false, true, null);
   }
 
   private static TestFilter emptyTestFilter() {


### PR DESCRIPTION
Introduce two new flags to allow for filtering of targets based on rule name:
- `--build_rule_filters`
- `--test_rule_filters`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering build and test targets by rule names using new command-line options.
  - Users can now specify rule name filters (including exclusions) to restrict which targets are built or tested.
  - Test filtering now supports rule name-based criteria in addition to existing filters.

- **Bug Fixes**
  - Improved equality checks for internal filter representations to ensure correct behavior with new rule filters.

- **Tests**
  - Added and updated tests to validate rule name filtering functionality for both build and test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->