### PR TITLE
Include unresolved symlink target into the source directory hash 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunction.java
@@ -187,9 +187,7 @@ public final class RecursiveFilesystemTraversalFunction implements SkyFunction {
         if (rootInfo.type.isSymlink()) {
           return RecursiveFilesystemTraversalValue.of(
               ResolvedFileFactory.danglingSymlink(
-                  traversal.root().asRootedPath(),
-                  rootInfo.unresolvedSymlinkTarget,
-                  rootInfo.metadata));
+                  traversal.root().asRootedPath(), rootInfo.unresolvedSymlinkTarget));
         } else {
           return RecursiveFilesystemTraversalValue.EMPTY;
         }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1922,6 +1922,25 @@ java_test(
 )
 
 java_test(
+    name = "SourceDirectoryIntegrationTest",
+    srcs = ["SourceDirectoryIntegrationTest.java"],
+    jvm_flags = [
+        "-DBAZEL_TRACK_SOURCE_DIRECTORIES=1",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/test/java/com/google/devtools/build/lib/buildtool/util",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "FileArtifactValueTest",
     timeout = "short",
     srcs = ["FileArtifactValueTest.java"],

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1930,6 +1930,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
@@ -830,8 +830,7 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
     PathFragment linkTarget = PathFragment.create("non_existent");
     parentOf(link).asPath().createDirectory();
     link.asPath().createSymbolicLink(linkTarget);
-    traverseAndAssertFiles(
-        fileLikeRoot(linkArtifact), danglingSymlink(link, linkTarget, EMPTY_METADATA));
+    traverseAndAssertFiles(fileLikeRoot(linkArtifact), danglingSymlink(link, linkTarget));
   }
 
   @Test
@@ -845,7 +844,7 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
     traverseAndAssertFiles(
         fileLikeRoot(dirArtifact),
         regularFile(file, EMPTY_METADATA),
-        danglingSymlink(link, linkTarget, EMPTY_METADATA));
+        danglingSymlink(link, linkTarget));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
@@ -1,0 +1,232 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.skyframe;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.BuildFailedException;
+import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
+import com.google.devtools.build.lib.events.EventKind;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test for invalidation of actions that consume source directories. */
+@RunWith(JUnit4.class)
+public final class SourceDirectoryIntegrationTest extends BuildIntegrationTestCase {
+
+  private Path sourceDir;
+
+  @Override
+  protected ImmutableSet<EventKind> additionalEventsToCollect() {
+    return ImmutableSet.of(EventKind.FINISH);
+  }
+
+  @Before
+  public void setUpGenrule() throws Exception {
+    write(
+        "foo/BUILD",
+        """
+        genrule(
+            name = "foo",
+            srcs = ["dir"],
+            outs = ["foo.out"],
+            cmd = "touch $@",
+        )
+        """);
+
+    sourceDir = getWorkspace().getRelative("foo/dir");
+    sourceDir.createDirectoryAndParents();
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("file1"), "content");
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("file2"), "content");
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("file3"), "other content");
+    sourceDir.getRelative("symlink").createSymbolicLink(PathFragment.create("file3"));
+    sourceDir
+        .getRelative("dangling_symlink")
+        .createSymbolicLink(PathFragment.create("does_not_exist"));
+
+    Path subDir = sourceDir.getRelative("subdir");
+    subDir.createDirectory();
+    FileSystemUtils.writeIsoLatin1(subDir.getRelative("file1"), "content");
+    FileSystemUtils.writeIsoLatin1(subDir.getRelative("file2"), "content");
+    FileSystemUtils.writeIsoLatin1(subDir.getRelative("file3"), "other content");
+    subDir.getRelative("symlink").createSymbolicLink(PathFragment.create("file3"));
+    subDir
+        .getRelative("dangling_symlink")
+        .createSymbolicLink(PathFragment.create("does_not_exist"));
+
+    subDir.getRelative("nested").createDirectory();
+    subDir.getRelative("nested2").createDirectory();
+    subDir.getRelative("nested_non_empty").createDirectory();
+    FileSystemUtils.writeIsoLatin1(subDir.getRelative("nested_non_empty/file1"), "content");
+
+    buildTarget("//foo");
+    assertContainsEvent(events.collector(), "Executing genrule //foo:foo");
+
+    events.collector().clear();
+  }
+
+  @Test
+  public void nothingModified_doesNotInvalidateAction() throws Exception {
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void touched_doesNotInvalidateAction() throws Exception {
+    sourceDir.setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void topLevelFileTouched_doesNotInvalidateAction() throws Exception {
+    sourceDir.getRelative("file1").setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void topLevelDirTouched_doesNotInvalidateAction() throws Exception {
+    sourceDir.getRelative("subdir").setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void nestedFileTouched_doesNotInvalidateAction() throws Exception {
+    sourceDir.getRelative("subdir/file1").setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void nestedDirTouched_doesNotInvalidateAction() throws Exception {
+    sourceDir.getRelative("subdir/nested").setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void topLevelFileDeleted_invalidatesAction() throws Exception {
+    sourceDir.getRelative("file1").delete();
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void nestedFileDeleted_invalidatesAction() throws Exception {
+    sourceDir.getRelative("subdir/file1").delete();
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void topLevelFileModified_invalidatesAction() throws Exception {
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("file1"), "modified content");
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void nestedFileModified_invalidatesAction() throws Exception {
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("subdir/file1"), "modified content");
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void topLevelFileAdded_invalidatesAction() throws Exception {
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("new_file"), "modified content");
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void nestedFileAdded_invalidatesAction() throws Exception {
+    FileSystemUtils.writeIsoLatin1(sourceDir.getRelative("subdir/new_file"), "modified content");
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void emptyDirDeleted_invalidatesAction() throws Exception {
+    sourceDir.getRelative("subdir/nested").delete();
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void fileReplacedByIdenticalSymlink_doesNotInvalidateAction() throws Exception {
+    Path file = sourceDir.getRelative("file1");
+    file.delete();
+    file.createSymbolicLink(sourceDir.getRelative("file2"));
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void fileReplacedByDifferentSymlink_invalidatesAction() throws Exception {
+    Path file = sourceDir.getRelative("file1");
+    file.delete();
+    file.createSymbolicLink(sourceDir.getRelative("file3"));
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  @Ignore("TODO(#25834)")
+  public void emptyDirReplacedWithIdenticalSymlink_doesNotInvalidateAction() throws Exception {
+    Path dir = sourceDir.getRelative("subdir/nested2");
+    dir.delete();
+    dir.createSymbolicLink(PathFragment.create("nested"));
+    assertNotInvalidatedByBuild();
+  }
+
+  @Test
+  public void emptyDirReplacedWithDifferentSymlink_invalidatesAction() throws Exception {
+    Path dir = sourceDir.getRelative("subdir/nested2");
+    dir.delete();
+    dir.createSymbolicLink(PathFragment.create("nested_non_empty"));
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void infiniteSymlinkExpansion() throws Exception {
+    Path dir = sourceDir.getRelative("subdir/nested2");
+    dir.delete();
+    dir.createSymbolicLink(PathFragment.create(".."));
+    assertThrows(BuildFailedException.class, () -> buildTarget("//foo"));
+    assertContainsEvent("infinite symlink expansion detected");
+    assertContainsEvent("foo/dir/subdir/nested2");
+  }
+
+  @Test
+  @Ignore("TODO(#25834)")
+  public void danglingSymlinkModified_invalidatesAction() throws Exception {
+    FileSystemUtils.ensureSymbolicLink(
+        sourceDir.getRelative("dangling_symlink"), PathFragment.create("still_does_not_exist"));
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  @Ignore("TODO(#25834)")
+  public void subPackageAdded_invalidatesAction() throws Exception {
+    FileSystemUtils.touchFile(sourceDir.getRelative("subdir/BUILD"));
+    assertInvalidatedByBuild();
+  }
+
+  private static final String GENRULE_EVENT = "Executing genrule //foo:foo";
+
+  private void assertInvalidatedByBuild() throws Exception {
+    buildTarget("//foo");
+    assertContainsEvent(events.collector(), GENRULE_EVENT);
+  }
+
+  private void assertNotInvalidatedByBuild() throws Exception {
+    buildTarget("//foo");
+    assertDoesNotContainEvent(events.collector(), GENRULE_EVENT);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -195,10 +196,18 @@ public final class SourceDirectoryIntegrationTest extends BuildIntegrationTestCa
   }
 
   @Test
-  @Ignore("TODO(#25834)")
   public void danglingSymlinkModified_invalidatesAction() throws Exception {
     FileSystemUtils.ensureSymbolicLink(
         sourceDir.getRelative("dangling_symlink"), PathFragment.create("still_does_not_exist"));
+    assertInvalidatedByBuild();
+  }
+
+  @Test
+  public void danglingSymlinkReplacedWithFile_invalidatesAction() throws Exception {
+    Path danglingSymlink = sourceDir.getRelative("dangling_symlink");
+    String target = danglingSymlink.readSymbolicLink().getPathString();
+    danglingSymlink.delete();
+    FileSystemUtils.writeContent(danglingSymlink, ISO_8859_1, target);
     assertInvalidatedByBuild();
   }
 


### PR DESCRIPTION
This makes it so that changes to the targets of unresolved symlinks invalidate actions that depend on the source directory containing them.

Work towards #25834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added integration tests to verify how changes in source directories and their contents affect build invalidation, including scenarios with files, directories, and symlinks.

- **Bug Fixes**
  - Improved handling of dangling symlinks during filesystem traversal to ensure more robust and consistent behavior.

- **Tests**
  - Introduced comprehensive tests covering source directory changes, symlink handling, package boundary violations, and symlink cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->