### PR TITLE
Speed up streamed-proto query output by distributing work to multiple threads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -83,7 +83,9 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
       var serializedSize = targetProtoBuffer.getSerializedSize();
       var headerSize = CodedOutputStream.computeUInt32SizeNoTag(serializedSize);
       var output = new byte[headerSize + serializedSize];
-      targetProtoBuffer.writeTo(CodedOutputStream.newInstance(output, headerSize, output.length - headerSize));
+      var codedOut = CodedOutputStream.newInstance(output, headerSize, output.length - headerSize);
+      targetProtoBuffer.writeTo(codedOut);
+      codedOut.flush();
       return output;
     } catch (IOException e) {
       throw new WrappedIOException(e);

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -16,8 +16,12 @@ package com.google.devtools.build.lib.query2.query.output;
 import com.google.devtools.build.lib.packages.LabelPrinter;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.stream.StreamSupport;
 
 /**
  * An output formatter that outputs a protocol buffer representation of a query result and outputs
@@ -34,13 +38,70 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
       final OutputStream out, final QueryOptions options, LabelPrinter labelPrinter) {
     return new OutputFormatterCallback<Target>() {
+      private final LabelPrinter ourLabelPrinter = labelPrinter;
+
       @Override
       public void processOutput(Iterable<Target> partialResult)
           throws IOException, InterruptedException {
-        for (Target target : partialResult) {
-          toTargetProtoBuffer(target, labelPrinter).writeDelimitedTo(out);
+        try {
+          StreamSupport.stream(partialResult.spliterator(), /* parallel= */true)
+              .map(this::toProto)
+              .map(StreamedProtoOutputFormatter::writeDelimited)
+              .forEach(this::writeToOutputStreamThreadSafe);
+        } catch (WrappedIOException e) {
+          throw e.getCause();
+        } catch (WrappedInterruptedException e) {
+          throw e.getCause();
+        }
+      }
+
+      private Build.Target toProto(Target target) {
+        try {
+          return toTargetProtoBuffer(target, ourLabelPrinter);
+        } catch (InterruptedException e) {
+          throw new WrappedInterruptedException(e);
+        }
+      }
+
+      private synchronized void writeToOutputStreamThreadSafe(ByteArrayOutputStream bout) {
+        try {
+          bout.writeTo(out);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
         }
       }
     };
+  }
+
+  private static ByteArrayOutputStream writeDelimited(Build.Target targetProtoBuffer) {
+    try {
+      var bout = new ByteArrayOutputStream(targetProtoBuffer.getSerializedSize() + 10);
+      targetProtoBuffer.writeDelimitedTo(bout);
+      return bout;
+    } catch (IOException e) {
+      throw new WrappedIOException(e);
+    }
+  }
+
+  private static class WrappedIOException extends RuntimeException {
+    private WrappedIOException(IOException cause) {
+      super(cause);
+    }
+
+    @Override
+    public synchronized IOException getCause() {
+      return (IOException) super.getCause();
+    }
+  }
+
+  private static class WrappedInterruptedException extends RuntimeException {
+    private WrappedInterruptedException(InterruptedException cause) {
+      super(cause);
+    }
+
+    @Override
+    public synchronized InterruptedException getCause() {
+      return (InterruptedException) super.getCause();
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -89,7 +89,7 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
     }
 
     @Override
-    public synchronized IOException getCause() {
+    public IOException getCause() {
       return (IOException) super.getCause();
     }
   }
@@ -100,7 +100,7 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
     }
 
     @Override
-    public synchronized InterruptedException getCause() {
+    public InterruptedException getCause() {
       return (InterruptedException) super.getCause();
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -44,7 +44,7 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
       public void processOutput(Iterable<Target> partialResult)
           throws IOException, InterruptedException {
         try {
-          StreamSupport.stream(partialResult.spliterator(), /* parallel= */true)
+          StreamSupport.stream(partialResult.spliterator(), /* parallel= */ true)
               .map(this::toProto)
               .map(StreamedProtoOutputFormatter::writeDelimited)
               .forEach(this::writeToOutputStreamThreadSafe);
@@ -67,7 +67,7 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
         try {
           bout.writeTo(out);
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new WrappedIOException(e);
         }
       }
     };

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -17,7 +17,6 @@ import com.google.devtools.build.lib.packages.LabelPrinter;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,6 +28,19 @@ import java.util.stream.StreamSupport;
  * on a {@code Build.QueryResult} object the full result can be reconstructed.
  */
 public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
+
+  /**
+   * The most bytes that protobuf delimited proto format will prepend to a proto message. See <a
+   * href="https://github.com/protocolbuffers/protobuf/blob/c11033dc27c3e9c1913e45b62fb5d4c5b5644b3e/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java#L72">
+   * <code>writeDelimitedTo</code></a> and <a
+   * href="https://github.com/protocolbuffers/protobuf/blob/c11033dc27c3e9c1913e45b62fb5d4c5b5644b3e/java/core/src/main/java/com/google/protobuf/WireFormat.java#L28">
+   * <code>MAX_VARINT32_SIZE</code></a>.
+   *
+   * <p>The value for int32 (used by {@code writeDelimitedTo} is actually 5, but we pick 10 just to
+   * be safe.
+   */
+  private static final int MAX_BYTES_FOR_VARINT32_ENCODING = 10;
+
   @Override
   public String getName() {
     return "streamed_proto";
@@ -75,7 +87,9 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
 
   private static ByteArrayOutputStream writeDelimited(Build.Target targetProtoBuffer) {
     try {
-      var bout = new ByteArrayOutputStream(targetProtoBuffer.getSerializedSize() + 10);
+      var bout =
+          new ByteArrayOutputStream(
+              targetProtoBuffer.getSerializedSize() + MAX_BYTES_FOR_VARINT32_ENCODING);
       targetProtoBuffer.writeDelimitedTo(bout);
       return bout;
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -18,7 +18,6 @@ import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 import com.google.protobuf.CodedOutputStream;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.stream.StreamSupport;

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -59,7 +59,11 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
           StreamSupport.stream(partialResult.spliterator(), /* parallel= */ true)
               .map(this::toProto)
               .map(StreamedProtoOutputFormatter::writeDelimited)
-              .forEach(this::writeToOutputStreamThreadSafe);
+              // I imagine forEachOrdered hurts performance somewhat in some cases. While we may
+              // not need to actually produce output in order, this code does not know whether
+              // ordering was requested. So we just always write it in order, and hope performance
+              // is OK.
+              .forEachOrdered(this::writeToOutputStreamThreadSafe);
         } catch (WrappedIOException e) {
           throw e.getCause();
         } catch (WrappedInterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -113,12 +113,25 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
   private static byte[] writeDelimited(Build.Target targetProtoBuffer) {
     try {
       var serializedSize = targetProtoBuffer.getSerializedSize();
-      var headerSize = CodedOutputStream.computeUInt32SizeNoTag(serializedSize);
-      var output = new byte[headerSize + serializedSize];
-      var codedOut = CodedOutputStream.newInstance(output, headerSize, output.length - headerSize);
-      targetProtoBuffer.writeTo(codedOut);
-      codedOut.flush();
+-     var headerSize = CodedOutputStream.computeUInt32SizeNoTag(serializedSize);
+-     var output = new byte[headerSize + serializedSize];
+-     var codedOut = CodedOutputStream.newInstance(output, headerSize, output.length - headerSize);
+-     targetProtoBuffer.writeTo(codedOut);
++     int headerSize = CodedOutputStream.computeUInt32SizeNoTag(serializedSize);
++     byte[] output = new byte[headerSize + serializedSize];
++
++     // 1. write the var-int length prefix
++     CodedOutputStream headerOut = CodedOutputStream.newInstance(output, 0, headerSize);
++     headerOut.writeUInt32NoTag(serializedSize);
++     headerOut.flush();
++
++     // 2. write the message bytes immediately after the prefix
++     CodedOutputStream bodyOut =
++         CodedOutputStream.newInstance(output, headerSize, serializedSize);
++     targetProtoBuffer.writeTo(bodyOut);
++     bodyOut.flush();
       return output;
+    }
     } catch (IOException e) {
       throw new WrappedIOException(e);
     }


### PR DESCRIPTION
This is a proposed fix for https://github.com/bazelbuild/bazel/issues/24304

This speeds up a fully warm `bazel query ...` by 54%, reducing wall time from 1m49s to 50s

Current state:
```
$ time bazel query '...' --output=streamed_proto > queryoutput4.streamedproto

real    1m48.768s
user    0m27.410s
sys     0m19.646s
```

This PR:
```
$ time bazel query '...' --output=streamed_proto > queryoutput5.streamedproto

real    0m49.938s
user    0m22.897s
sys     0m16.161s
```

_💁‍♂️ Note: when combined with https://github.com/bazelbuild/bazel/pull/24298, total wall time is 37s, an overall reduction of 66%._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved performance for streaming large sets of proto targets by introducing asynchronous, chunked processing and streaming.
- **Bug Fixes**
  - Enhanced reliability and responsiveness when handling large queries by managing concurrency and backpressure during output streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->