### PR TITLE
Enable timeout propagation for remote actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -118,7 +118,31 @@ public class ExecutionRequirements {
   }
 
   /** If specified, the timeout of this action in seconds. Must be decimal integer. */
-  public static final String TIMEOUT = "timeout";
+  public static final ParseableRequirement TIMEOUT =
+      ParseableRequirement.create(
+          "timeout:<int>",
+          Pattern.compile("timeout:(.+)"),
+          s -> {
+            Preconditions.checkNotNull(s);
+
+            int value;
+            try {
+              value = Integer.parseInt(s);
+            } catch (NumberFormatException e) {
+              return "can't be parsed as an integer";
+            }
+
+            // De-and-reserialize & compare to only allow canonical integer formats.
+            if (!Integer.toString(value).equals(s)) {
+              return "must be in canonical format (e.g. '4' instead of '+04')";
+            }
+
+            if (value < 1) {
+              return "can't be zero or negative";
+            }
+
+            return null;
+          });
 
   /** If an action would not successfully run other than on Darwin. */
   public static final String REQUIRES_DARWIN = "requires-darwin";

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -119,7 +119,7 @@ public class StandaloneTestStrategy extends TestStrategy {
       // for this.
       executionInfo.put(ExecutionRequirements.NO_CACHE, "");
     }
-    executionInfo.put(ExecutionRequirements.TIMEOUT, "" + getTimeout(action).toSeconds());
+    executionInfo.put("timeout", "" + getTimeout(action).toSeconds());
 
     SimpleSpawn.LocalResourcesSupplier localResourcesSupplier =
         () ->

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -58,6 +58,7 @@ public final class TargetUtils {
         || tag.startsWith("disable-")
         || tag.startsWith("cpu:")
         || tag.equals(ExecutionRequirements.LOCAL)
+        || tag.equals(ExecutionRequirements.TIMEOUT)
         || tag.equals(ExecutionRequirements.WORKER_KEY_MNEMONIC)
         || tag.startsWith("resources:");
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -58,7 +58,7 @@ public final class TargetUtils {
         || tag.startsWith("disable-")
         || tag.startsWith("cpu:")
         || tag.equals(ExecutionRequirements.LOCAL)
-        || tag.equals(ExecutionRequirements.TIMEOUT)
+        || tag.startsWith("timeout")
         || tag.equals(ExecutionRequirements.WORKER_KEY_MNEMONIC)
         || tag.startsWith("resources:");
   }

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -222,6 +222,8 @@ message Spawn {
     COMMAND_LINE_EXPANSION_FAILURE = 7 [(metadata) = { exit_code: 1 }];
     EXEC_IO_EXCEPTION = 8 [(metadata) = { exit_code: 36 }];
     INVALID_TIMEOUT = 9 [(metadata) = { exit_code: 1 }];
+    DUPLICATE_TIMEOUT_TAGS = 16 [(metadata) = { exit_code: 1 }];
+    INVALID_TIMEOUT_TAG = 17 [(metadata) = { exit_code: 1 }];
     INVALID_REMOTE_EXECUTION_PROPERTIES = 10 [(metadata) = { exit_code: 1 }];
     NO_USABLE_STRATEGY_FOUND = 11 [(metadata) = { exit_code: 1 }];
     // TODO(b/138456686): this code should be deprecated when SpawnResult is

--- a/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
@@ -224,6 +224,19 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
   }
 
   @Test
+  public void testExecutionInfo_withPrefixTimeout() throws Exception {
+    scratch.file(
+        "tests/BUILD",
+        "load('//test_defs:foo_binary.bzl', 'foo_binary')",
+        "foo_binary(name = 'with-prefix-timeout', srcs=['sh.sh'], tags=['timeout:123', 'wrong-tag'])");
+
+    Rule withCpuPrefix = (Rule) getTarget("//tests:with-prefix-timeout");
+
+    Map<String, String> execInfo = TargetUtils.getExecutionInfo(withCpuPrefix);
+    assertThat(execInfo).containsExactly("timeout:123", "");
+  }
+
+  @Test
   public void testExecutionInfo_withLocalTag() throws Exception {
     scratch.file(
         "tests/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -416,7 +416,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         "  inputs = ruleContext.files.srcs,",
         "  outputs = ruleContext.files.srcs,",
         "  env = {'a' : 'b'},",
-        "  execution_requirements = {'timeout' : '10', 'block-network' : 'foo'},",
+        "  execution_requirements = {'block-network' : 'foo'},",
         "  mnemonic = 'DummyMnemonic',",
         "  command = 'dummy_command',",
         "  progress_message = 'dummy_message')");
@@ -425,8 +425,29 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
             Iterables.getOnlyElement(
                 ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
     assertThat(action.getIncompleteEnvironmentForTesting()).containsExactly("a", "b");
-    // We expect "timeout" to be filtered by TargetUtils.
     assertThat(action.getExecutionInfo()).containsExactly("block-network", "foo");
+  }
+
+  @Test
+  public void testCreateSpawnActionEnvAndExecInfo_withTimeout() throws Exception {
+    StarlarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    setRuleContext(ruleContext);
+    ev.exec(
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  execution_requirements = {",
+        "    'timeout': '42',",
+        "  },",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command',",
+        "  progress_message = 'dummy_message')");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertThat(action.getExecutionInfo())
+        .containsExactly("timeout", "42");
   }
 
   @Test


### PR DESCRIPTION
When building using remote execution,
action timeouts sometimes need to be adjusted
per action to ensure reasonable timeouts are set.

This change will allow better control over how
actions behave and encourage users to
optimize their actions since the global default timeout does not have to be set to the absolute largest
action timeout in the graph.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for timeout tags in execution requirements, allowing for more flexible and validated timeout specifications.
  - Enhanced error reporting for duplicate or invalid timeout tags with specific failure codes.

- **Bug Fixes**
  - More robust validation and canonical formatting for timeout values to prevent invalid entries.

- **Tests**
  - Added and updated tests to verify correct handling and extraction of timeout tags in execution info.

- **Documentation**
  - Updated failure codes to document new error cases for timeout tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->