### PR TITLE
Allow construction of a full jdk repo from a build target

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_runtime.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_runtime.bzl
@@ -100,7 +100,7 @@ def _java_runtime_rule_impl(ctx):
     java_binary_exec_path = paths.get_relative(java_home, _get_bin_java(ctx))
     java_binary_runfiles_path = _get_runfiles_java_executable(ctx, java_home, ctx.label)
 
-    java = ctx.file.java
+    java = ctx.executable.java.path
     if java:
         if paths.is_absolute(java_home):
             fail("'java_home' with an absolute path requires 'java' to be empty.")
@@ -204,7 +204,6 @@ The libraries that are statically linked with the launcher for hermetic deployme
             """,
         ),
         "java": attr.label(
-            allow_single_file = True,
             executable = True,
             cfg = "target",
             doc = """

--- a/src/main/starlark/builtins_bzl/common/java/java_runtime.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_runtime.bzl
@@ -100,7 +100,7 @@ def _java_runtime_rule_impl(ctx):
     java_binary_exec_path = paths.get_relative(java_home, _get_bin_java(ctx))
     java_binary_runfiles_path = _get_runfiles_java_executable(ctx, java_home, ctx.label)
 
-    java = ctx.executable.java.path
+    java = ctx.executable.java
     if java:
         if paths.is_absolute(java_home):
             fail("'java_home' with an absolute path requires 'java' to be empty.")


### PR DESCRIPTION
Right now there seems to be no way to create a full java runtime from a build target.  This adds that capability by removing the restriction that the 'java' attr in java_runtime be a single_file.