### PR TITLE
Cache dex syntethic context in dex builder

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
@@ -73,7 +73,7 @@ public class CompatDexBuilder {
 
   private static final long ONE_MEG = 1024 * 1024;
 
-  private static class ContextConsumer implements SyntheticInfoConsumer {
+  public static class ContextConsumer implements SyntheticInfoConsumer {
 
     // After compilation this will be non-null iff the compiled class is a D8 synthesized class.
     ClassReference sythesizedPrimaryClass = null;
@@ -113,7 +113,7 @@ public class CompatDexBuilder {
 
   private static class DexConsumer implements DexIndexedConsumer {
 
-    final ContextConsumer contextConsumer = new ContextConsumer();
+    ContextConsumer contextConsumer = new ContextConsumer();
     byte[] bytes;
 
     @Override
@@ -129,6 +129,10 @@ public class CompatDexBuilder {
 
     void setBytes(byte[] byteCode) {
       this.bytes = byteCode;
+    }
+
+    void setContextConsumer(ContextConsumer contextConsumer) {
+        this.contextConsumer = contextConsumer;
     }
 
     ContextConsumer getContextConsumer() {
@@ -148,17 +152,17 @@ public class CompatDexBuilder {
       PrintStream realStdErr = System.err;
 
       // Set up dexer cache
-      Cache<DexingKeyR8, byte[]> dexCache =
+      Cache<DexingKeyR8, DexingEntryR8> dexCache =
           CacheBuilder.newBuilder()
               // Use at most 200 MB for cache and leave at least 25 MB of heap space alone. For
               // reference:
               // .class & class.dex files are around 1-5 KB, so this fits ~30K-35K class-dex pairs.
               .maximumWeight(min(Runtime.getRuntime().maxMemory() - 25 * ONE_MEG, 200 * ONE_MEG))
               .weigher(
-                  new Weigher<DexingKeyR8, byte[]>() {
+                  new Weigher<DexingKeyR8, DexingEntryR8>() {
                     @Override
-                    public int weigh(DexingKeyR8 key, byte[] value) {
-                      return key.classfileContent().length + value.length;
+                    public int weigh(DexingKeyR8 key, DexingEntryR8 value) {
+                      return key.classfileContent().length + value.dexContent().length;
                     }
                   })
               .build();
@@ -187,7 +191,7 @@ public class CompatDexBuilder {
   }
 
   private int processRequest(
-      @Nullable Cache<DexingKeyR8, byte[]> dexCache,
+      @Nullable Cache<DexingKeyR8, DexingEntryR8> dexCache,
       DiagnosticsHandler diagnosticsHandler,
       List<String> args,
       PrintWriter pw) {
@@ -205,7 +209,7 @@ public class CompatDexBuilder {
 
   @SuppressWarnings("JdkObsolete")
   private void dexEntries(
-      @Nullable Cache<DexingKeyR8, byte[]> dexCache,
+      @Nullable Cache<DexingKeyR8, DexingEntryR8> dexCache,
       List<String> args,
       DiagnosticsHandler dexDiagnosticsHandler)
       throws IOException, InterruptedException, ExecutionException, OptionsParsingException {
@@ -332,7 +336,7 @@ public class CompatDexBuilder {
   }
 
   private DexConsumer dexEntry(
-      @Nullable Cache<DexingKeyR8, byte[]> dexCache,
+      @Nullable Cache<DexingKeyR8, DexingEntryR8> dexCache,
       ZipFile zipFile,
       ZipEntry classEntry,
       CompilationMode mode,
@@ -349,18 +353,20 @@ public class CompatDexBuilder {
         .setMinApiLevel(minSdkVersion)
         .setDisableDesugaring(true)
         .setIntermediate(true);
-    byte[] cachedDexBytes = null;
+
+    DexingEntryR8 cachedDexEntry = null;
     byte[] classFileBytes = null;
     try (InputStream stream = zipFile.getInputStream(classEntry)) {
       classFileBytes = ByteStreams.toByteArray(stream);
       if (dexCache != null) {
         // If the cache exists, check for cache validity.
-        cachedDexBytes =
+        cachedDexEntry =
             dexCache.getIfPresent(DexingKeyR8.create(mode, minSdkVersion, classFileBytes));
       }
-      if (cachedDexBytes != null) {
+      if (cachedDexEntry != null) {
         // Cache hit: quit early and return the data
-        consumer.setBytes(cachedDexBytes);
+        consumer.setBytes(cachedDexEntry.dexContent());
+        consumer.setContextConsumer(cachedDexEntry.contextConsumer());
         return consumer;
       }
       builder.addClassProgramData(
@@ -371,7 +377,9 @@ public class CompatDexBuilder {
     D8.run(builder.build(), executor);
     // After dexing finishes, store the dexed output into the cache.
     if (dexCache != null) {
-      dexCache.put(DexingKeyR8.create(mode, minSdkVersion, classFileBytes), consumer.getBytes());
+      dexCache.put(
+              DexingKeyR8.create(mode, minSdkVersion, classFileBytes),
+              DexingEntryR8.create(consumer.getBytes(), consumer.getContextConsumer()));
     }
     return consumer;
   }
@@ -395,6 +403,25 @@ public class CompatDexBuilder {
     @SuppressWarnings("mutable")
     public abstract byte[] classfileContent();
   }
+
+  /**
+   * Represents a cache entry in the dex cache. 
+   */
+  @AutoValue
+  public abstract static class DexingEntryR8 {
+    public static DexingEntryR8 create(
+         byte[] dexContent, ContextConsumer contextConsumer) {
+      return new AutoValue_CompatDexBuilder_DexingEntryR8(
+          dexContent, contextConsumer);
+    }
+
+    @SuppressWarnings("mutable")
+    public abstract byte[] dexContent();
+
+    @SuppressWarnings("mutable")
+    public abstract ContextConsumer contextConsumer();
+  }
+
 
   /**
    * Custom implementation of DiagnosticsHandler that writes the info/warning diagnostics messages

--- a/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
@@ -33,6 +33,7 @@ import com.android.tools.r8.origin.PathOrigin;
 import com.android.tools.r8.references.ClassReference;
 import com.android.tools.r8.utils.StringDiagnostic;
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.Weigher;
@@ -190,7 +191,8 @@ public class CompatDexBuilder {
     }
   }
 
-  private int processRequest(
+  @VisibleForTesting
+  int processRequest(
       @Nullable Cache<DexingKeyR8, DexingEntryR8> dexCache,
       DiagnosticsHandler diagnosticsHandler,
       List<String> args,


### PR DESCRIPTION

There is a data race when using workers when there are multiple libraries that include the same class. This is more likely to happen when building multiple android_binary targets in a single invocation. When a cached entry is found, only the dex content is used and the sythetic info is ignored. In those instances, the dex archive will be incorrectly created and might lead to failures during dex merging

Fixes: https://github.com/bazelbuild/rules_android/issues/300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dexing process by caching both dex byte content and associated synthetic context information, enhancing efficiency in repeated builds.
- **Tests**
  - Added a new test to verify correct caching of synthetic context data during dexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->