### PR TITLE
Check that digesting consumes the expected number of bytes.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -273,7 +273,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       return new DirectoryArtifactValue(path.getLastModifiedTime());
     }
     if (digest == null) {
-      digest = DigestUtils.getDigestWithManualFallback(path, xattrProvider);
+      digest = DigestUtils.getDigestWithManualFallback(path, size, xattrProvider);
     }
     Preconditions.checkState(digest != null, path);
     return createForNormalFile(digest, proxy, size);

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -126,11 +126,11 @@ public /*final*/ class ConfiguredRuleClassProvider
 
     @Override
     protected synchronized byte[] getFastDigest(PathFragment path) {
-      return getDigest(path);
+      return getDigest(path, -1);
     }
 
     @Override
-    protected synchronized byte[] getDigest(PathFragment path) {
+    protected synchronized byte[] getDigest(PathFragment path, long expectedSize) {
       return getDigestFunction().getHashFunction().hashString(path.toString(), UTF_8).asBytes();
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/RunfilesTreeUpdater.java
@@ -138,8 +138,8 @@ public class RunfilesTreeUpdater {
       if (tree.getSymlinksMode() != SKIP
           && !outputManifest.isSymbolicLink()
           && Arrays.equals(
-              DigestUtils.getDigestWithManualFallback(outputManifest, xattrProvider),
-              DigestUtils.getDigestWithManualFallback(inputManifest, xattrProvider))
+              DigestUtils.getDigestWithManualFallbackWhenSizeUnknown(outputManifest, xattrProvider),
+              DigestUtils.getDigestWithManualFallbackWhenSizeUnknown(inputManifest, xattrProvider))
           && (OS.getCurrent() != OS.WINDOWS || isRunfilesDirectoryPopulated(runfilesDirPath))) {
         return;
       }

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -177,7 +177,8 @@ public abstract class SpawnLogContext implements ActionContext {
     // Try to obtain a digest from the filesystem.
     return builder
         .setHash(
-            HashCode.fromBytes(DigestUtils.getDigestWithManualFallback(path, xattrProvider))
+            HashCode.fromBytes(
+                    DigestUtils.getDigestWithManualFallback(path, fileSize, xattrProvider))
                 .toString())
         .setSizeBytes(fileSize)
         .build();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -434,7 +434,7 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     // Try to obtain a fast digest through a stat. This is only possible for in-memory files.
     // The parent path has already been canonicalized by resolveSymbolicLinks, so FOLLOW_NONE is
@@ -443,7 +443,7 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
     if (status instanceof FileStatusWithDigest) {
       return ((FileStatusWithDigest) status).getDigest();
     }
-    return localFs.getPath(path).getDigest();
+    return localFs.getPath(path).getDigest(expectedSize);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -72,7 +72,8 @@ public class DigestUtil {
   }
 
   public Digest compute(Path file, long fileSize) throws IOException {
-    return buildDigest(DigestUtils.getDigestWithManualFallback(file, xattrProvider), fileSize);
+    return buildDigest(
+        DigestUtils.getDigestWithManualFallback(file, fileSize, xattrProvider), fileSize);
   }
 
   public Digest compute(VirtualActionInput input) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -557,7 +557,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       // possible to hit the digest cache - we probably already computed the digest for the
       // target during previous action execution.
       Path pathToDigest = isResolvedSymlink ? statAndValue.realPath() : statAndValue.pathNoFollow();
-      actualDigest = DigestUtils.manuallyComputeDigest(pathToDigest);
+      actualDigest = DigestUtils.manuallyComputeDigest(pathToDigest, value.getSize());
     }
 
     if (!isResolvedSymlink) {

--- a/src/main/java/com/google/devtools/build/lib/testing/vfs/SpiedFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/testing/vfs/SpiedFileSystem.java
@@ -58,8 +58,8 @@ public class SpiedFileSystem extends DelegateFileSystem {
   }
 
   @Override
-  public byte[] getDigest(PathFragment path) throws IOException {
-    return super.getDigest(path);
+  public byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
+    return super.getDigest(path, expectedSize);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -446,11 +446,11 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
     String name = path.toString();
     long startTime = Profiler.nanoTimeMaybe();
     try {
-      return super.getDigest(path);
+      return super.getDigest(path, expectedSize);
     } finally {
       profiler.logSimpleTask(startTime, ProfilerTask.VFS_MD5, name);
     }

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -420,11 +420,11 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
+  protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
     String name = path.toString();
     long startTime = Profiler.nanoTimeMaybe();
     try {
-      return super.getDigest(path);
+      return super.getDigest(path, expectedSize);
     } finally {
       profiler.logSimpleTask(startTime, ProfilerTask.VFS_MD5, name);
     }

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -227,8 +227,8 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected byte[] getDigest(PathFragment path) throws IOException {
-    return delegateFs.getDigest(toDelegatePath(path));
+  protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
+    return delegateFs.getDigest(toDelegatePath(path), expectedSize);
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/StubbableFSBuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StubbableFSBuildViewTest.java
@@ -137,7 +137,7 @@ public class StubbableFSBuildViewTest extends BuildViewTestBase {
       if (stubbedFastDigestErrors.containsKey(path)) {
         throw stubbedFastDigestErrors.get(path);
       }
-      return getDigest(path);
+      return getDigest(path, -1);
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/SingleBuildFileCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SingleBuildFileCacheTest.java
@@ -61,9 +61,9 @@ public class SingleBuildFileCacheTest {
           }
 
           @Override
-          protected byte[] getDigest(PathFragment path) throws IOException {
+          protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
             byte[] override = digestOverrides.get(path.getPathString());
-            return override != null ? override : super.getDigest(path);
+            return override != null ? override : super.getDigest(path, expectedSize);
           }
 
           @Override

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -86,11 +86,11 @@ public abstract class SpawnLogContextTestBase {
 
     @Override
     protected byte[] getFastDigest(PathFragment path) throws IOException {
-      return super.getDigest(path);
+      return super.getDigest(path, -1);
     }
 
     @Override
-    protected byte[] getDigest(PathFragment path) throws IOException {
+    protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
       throw new UnsupportedOperationException();
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.stream;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -578,9 +579,9 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     // Verify that we don't fall back to a slow digest.
     reset(fs);
     assertThat(actionFs.getFastDigest(path)).isEqualTo(getDigest("local contents"));
-    verify(fs, never()).getDigest(any());
+    verify(fs, never()).getDigest(any(), anyLong());
 
-    assertThat(actionFs.getDigest(path)).isEqualTo(getDigest("local contents"));
+    assertThat(actionFs.getDigest(path, -1)).isEqualTo(getDigest("local contents"));
   }
 
   @Test
@@ -593,9 +594,9 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     // Verify that we don't fall back to a slow digest.
     reset(fs);
     assertThat(actionFs.getFastDigest(path)).isEqualTo(getDigest("remote contents"));
-    verify(fs, never()).getDigest(any());
+    verify(fs, never()).getDigest(any(), anyLong());
 
-    assertThat(actionFs.getDigest(path)).isEqualTo(getDigest("remote contents"));
+    assertThat(actionFs.getDigest(path, -1)).isEqualTo(getDigest("remote contents"));
   }
 
   @Test
@@ -606,7 +607,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     injectRemoteFile(actionFs, artifact.getPath().asFragment(), "remote contents");
 
     assertThat(actionFs.getFastDigest(path)).isEqualTo(getDigest("remote contents"));
-    assertThat(actionFs.getDigest(path)).isEqualTo(getDigest("remote contents"));
+    assertThat(actionFs.getDigest(path, -1)).isEqualTo(getDigest("remote contents"));
   }
 
   @Test
@@ -617,7 +618,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     writeLocalFile(actionFs, artifact.getPath().asFragment(), "local contents");
 
     assertThat(actionFs.getFastDigest(path)).isNull();
-    assertThat(actionFs.getDigest(path)).isEqualTo(getDigest("local contents"));
+    assertThat(actionFs.getDigest(path, -1)).isEqualTo(getDigest("local contents"));
   }
 
   @Test
@@ -627,7 +628,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     PathFragment path = artifact.getPath().asFragment();
 
     assertThrows(FileNotFoundException.class, () -> actionFs.getFastDigest(path));
-    assertThrows(FileNotFoundException.class, () -> actionFs.getDigest(path));
+    assertThrows(FileNotFoundException.class, () -> actionFs.getDigest(path, -1));
   }
 
   @Test
@@ -650,7 +651,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
       assertThat(actionFs.getFastDigest(linkPath)).isEqualTo(getDigest("content"));
     }
 
-    assertThat(actionFs.getDigest(linkPath)).isEqualTo(getDigest("content"));
+    assertThat(actionFs.getDigest(linkPath, -1)).isEqualTo(getDigest("content"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -385,7 +385,7 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1"), -1))
         .isEqualTo(toBinaryDigest(d1));
     assertThat(readContent(execRoot.getRelative("outputs/file1"), UTF_8)).isEqualTo("content1");
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -422,9 +422,10 @@ public class RemoteExecutionServiceTest {
 
     // assert
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/a/dir/foo")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/a/dir/foo"), -1))
         .isEqualTo(toBinaryDigest(fooDigest));
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/a/dir/subdir/bar")))
+    assertThat(
+            actionFs.getDigest(execRoot.asFragment().getRelative("outputs/a/dir/subdir/bar"), -1))
         .isEqualTo(toBinaryDigest(barDigest));
     assertThat(readContent(execRoot.getRelative("outputs/a/dir/foo"), UTF_8))
         .isEqualTo("foo-contents");
@@ -1150,9 +1151,9 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1"), -1))
         .isEqualTo(toBinaryDigest(d1));
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file2")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file2"), -1))
         .isEqualTo(toBinaryDigest(d2));
     assertThat(execRoot.getRelative("outputs/file1").exists()).isTrue();
     assertThat(execRoot.getRelative("outputs/file2").exists()).isFalse();
@@ -1184,9 +1185,9 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1"), -1))
         .isEqualTo(toBinaryDigest(d1));
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file2")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file2"), -1))
         .isEqualTo(toBinaryDigest(d2));
     assertThat(execRoot.getRelative("outputs/file1").exists()).isFalse();
     assertThat(execRoot.getRelative("outputs/file2").exists()).isFalse();
@@ -1234,9 +1235,9 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/file1")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/file1"), -1))
         .isEqualTo(toBinaryDigest(d1));
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/a/file2")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/a/file2"), -1))
         .isEqualTo(toBinaryDigest(d2));
     assertThat(execRoot.getRelative("outputs/dir/file1").exists()).isTrue();
     assertThat(execRoot.getRelative("outputs/dir/a").exists()).isFalse();
@@ -1283,9 +1284,9 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/file1")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/file1"), -1))
         .isEqualTo(toBinaryDigest(d1));
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/a/file2")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/dir/a/file2"), -1))
         .isEqualTo(toBinaryDigest(d2));
     assertThat(execRoot.getRelative("outputs/dir/file1").exists()).isFalse();
     assertThat(execRoot.getRelative("outputs/dir/a").exists()).isFalse();
@@ -1366,8 +1367,10 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(outErr.getOutputPathFragment())).isEqualTo(toBinaryDigest(dOut));
-    assertThat(actionFs.getDigest(outErr.getErrorPathFragment())).isEqualTo(toBinaryDigest(dErr));
+    assertThat(actionFs.getDigest(outErr.getOutputPathFragment(), -1))
+        .isEqualTo(toBinaryDigest(dOut));
+    assertThat(actionFs.getDigest(outErr.getErrorPathFragment(), -1))
+        .isEqualTo(toBinaryDigest(dErr));
     assertThat(outErr.outAsLatin1()).isEqualTo("stdout");
     assertThat(outErr.errAsLatin1()).isEqualTo("stderr");
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
@@ -1400,8 +1403,10 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(outErr.getOutputPathFragment())).isEqualTo(toBinaryDigest(dOut));
-    assertThat(actionFs.getDigest(outErr.getErrorPathFragment())).isEqualTo(toBinaryDigest(dErr));
+    assertThat(actionFs.getDigest(outErr.getOutputPathFragment(), -1))
+        .isEqualTo(toBinaryDigest(dOut));
+    assertThat(actionFs.getDigest(outErr.getErrorPathFragment(), -1))
+        .isEqualTo(toBinaryDigest(dErr));
     assertThat(inMemoryOutput).isNull();
     assertThat(outErr.outAsLatin1()).isEqualTo("stdout");
     assertThat(outErr.errAsLatin1()).isEqualTo("stderr");
@@ -1443,9 +1448,9 @@ public class RemoteExecutionServiceTest {
     assertThat(inMemoryOutput.getOutput())
         .isEqualTo(ActionsTestUtil.createArtifact(artifactRoot, "file1"));
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file1"), -1))
         .isEqualTo(toBinaryDigest(d1));
-    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file2")))
+    assertThat(actionFs.getDigest(execRoot.asFragment().getRelative("outputs/file2"), -1))
         .isEqualTo(toBinaryDigest(d2));
     assertThat(execRoot.getRelative("outputs/file1").exists()).isFalse();
     assertThat(execRoot.getRelative("outputs/file2").exists()).isFalse();
@@ -1554,9 +1559,11 @@ public class RemoteExecutionServiceTest {
 
     assertThat(inMemoryOutput).isNull();
     RemoteActionFileSystem actionFs = context.getActionFileSystem();
-    assertThat(actionFs.getDigest(output1.getPath().asFragment())).isEqualTo(toBinaryDigest(d1));
+    assertThat(actionFs.getDigest(output1.getPath().asFragment(), -1))
+        .isEqualTo(toBinaryDigest(d1));
     assertThat(readContent(output1.getPath(), UTF_8)).isEqualTo("content1");
-    assertThat(actionFs.getDigest(output2.getPath().asFragment())).isEqualTo(toBinaryDigest(d2));
+    assertThat(actionFs.getDigest(output2.getPath().asFragment(), -1))
+        .isEqualTo(toBinaryDigest(d2));
     assertThat(readContent(output2.getPath(), UTF_8)).isEqualTo("content2");
     assertThat(context.isLockOutputFilesCalled()).isTrue();
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
@@ -119,8 +119,10 @@ public class ArtifactFunctionTest extends ArtifactFunctionTestCase {
     setupRoot(
         new CustomInMemoryFs() {
           @Override
-          public byte[] getDigest(PathFragment path) throws IOException {
-            return path.getBaseName().equals("unreadable") ? expectedDigest : super.getDigest(path);
+          public byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
+            return path.getBaseName().equals("unreadable")
+                ? expectedDigest
+                : super.getDigest(path, expectedSize);
           }
         });
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTestCase.java
@@ -180,7 +180,7 @@ abstract class ArtifactFunctionTestCase {
     @Override
     @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     protected byte[] getFastDigest(PathFragment path) throws IOException {
-      return fastDigest ? getDigest(path) : null;
+      return fastDigest ? getDigest(path, -1) : null;
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -186,7 +186,7 @@ public final class FileArtifactValueTest {
     FileSystem fs =
         new InMemoryFileSystem(DigestHashFunction.SHA256) {
           @Override
-          public byte[] getDigest(PathFragment path) throws IOException {
+          public byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
             throw exception;
           }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileFunctionTest.java
@@ -895,9 +895,9 @@ public class FileFunctionTest {
     fs =
         new CustomInMemoryFs(manualClock) {
           @Override
-          protected byte[] getDigest(PathFragment path) throws IOException {
+          protected byte[] getDigest(PathFragment path, long expectedSize) throws IOException {
             digestCalls.incrementAndGet();
-            return super.getDigest(path);
+            return super.getDigest(path, expectedSize);
           }
         };
     pkgRoot = Root.fromPath(fs.getPath("/root"));
@@ -1816,7 +1816,7 @@ public class FileFunctionTest {
       if (stubbedFastDigestErrors.containsKey(path)) {
         throw stubbedFastDigestErrors.get(path);
       }
-      return fastDigest ? getDigest(path) : null;
+      return fastDigest ? getDigest(path, -1) : null;
     }
 
     void stubStat(Path path, @Nullable FileStatus stubbedResult) {

--- a/src/test/java/com/google/devtools/build/lib/unix/UnixDigestHashAttributeNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/unix/UnixDigestHashAttributeNameTest.java
@@ -42,7 +42,9 @@ public class UnixDigestHashAttributeNameTest extends FileSystemTest {
     // Instead of actually trying to access this file, a call to getxattr() should be made. We
     // intercept this call and return a fake extended attribute value, thereby causing the checksum
     // computation to be skipped entirely.
-    assertThat(DigestUtils.getDigestWithManualFallback(absolutize("myfile"), SyscallCache.NO_CACHE))
+    assertThat(
+            DigestUtils.getDigestWithManualFallback(
+                absolutize("myfile"), 123, SyscallCache.NO_CACHE))
         .isEqualTo(FAKE_DIGEST);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -1794,11 +1794,14 @@ public abstract class FileSystemTest {
 
   @Test
   public void testGetDigest() throws Exception {
-    byte[] buffer = new byte[500000];
+    var size = 500000;
+    byte[] buffer = new byte[size];
     for (int i = 0; i < buffer.length; ++i) {
       buffer[i] = 1;
     }
     FileSystemUtils.writeContent(xFile, buffer);
+    assertThrows(IOException.class, () -> xFile.getDigest(size + 1));
+    assertThrows(IOException.class, () -> xFile.getDigest(size - 1));
     Fingerprint fp = new Fingerprint(digestHashFunction);
     fp.addBytes(buffer);
     assertThat(fp.hexDigestAndReset())


### PR DESCRIPTION
In Bazel, the time a file is `stat`ed to find its size can be very far from the time the file's digest is computed, which creates a window for shenanigans. Allow passing the expected size into `Path.getDigest` and raise an error there if the number of digested bytes doesn't match the previously seen size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File digest computation now supports explicit file size validation, improving accuracy and error detection for mismatched file sizes during hashing.

- **Bug Fixes**
  - Enhanced error reporting when file size does not match the expected value during digest operations.

- **Tests**
  - Updated tests to verify file digest behavior with explicit file size parameters and to check for proper error handling on size mismatches.

- **Refactor**
  - Digest-related methods and their usage were updated to consistently accept and utilize file size information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->