### PR TITLE
turbine support worker mode

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/BUILD
@@ -7,12 +7,16 @@ package(
 
 java_binary(
     name = "turbine_direct_binary",
-    main_class = "com.google.turbine.main.Main",
+    main_class = "com.google.devtools.build.java.turbine.TurbineWorkerWrapper",
+    srcs = ["TurbineWorkerWrapper.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
+        "//third_party:turbine",
+    ],
     runtime_deps = [
         "//src/main/protobuf:deps_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party:turbine",
     ],
 )
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/TurbineWorkerWrapper.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/TurbineWorkerWrapper.java
@@ -1,0 +1,51 @@
+package com.google.devtools.build.java.turbine;
+
+import com.google.turbine.main.Main;
+import com.google.devtools.build.lib.worker.ProtoWorkerMessageProcessor;
+import com.google.devtools.build.lib.worker.WorkRequestHandler;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * A Wrapper for Turbine to support multiplex worker
+ */
+public class TurbineWorkerWrapper {
+
+  public static void main(String[] args) throws IOException {
+    if (args.length == 1 && args[0].equals("--persistent_worker")) {
+      WorkRequestHandler workerHandler =
+          new WorkRequestHandler.WorkRequestHandlerBuilder(
+              TurbineWorkerWrapper::turbine,
+              System.err,
+              new ProtoWorkerMessageProcessor(System.in, System.out))
+              .setCpuUsageBeforeGc(Duration.ofSeconds(10))
+              .build();
+      int exitCode = 1;
+      try {
+        workerHandler.processRequests();
+        exitCode = 0;
+      } catch (IOException e) {
+        System.err.println(e.getMessage());
+      } finally {
+        // Prevent hanging threads from keeping the worker alive.
+        System.exit(exitCode);
+      }
+    } else {
+      Main.main(args);
+    }
+  }
+
+  private static int turbine(List<String> args, PrintWriter pw) {
+      try {
+          Main.compile(args.toArray(new String[0]));
+      } catch (Throwable e) {
+          System.err.println(e.getMessage());
+          return 1;
+      }
+      return 0;
+  }
+
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -132,7 +132,7 @@ public final class JavaHeaderCompileAction extends SpawnAction {
   public static final class Builder {
 
     private static final ParamFileInfo PARAM_FILE_INFO =
-        ParamFileInfo.builder(UNQUOTED).setCharset(ISO_8859_1).build();
+        ParamFileInfo.builder(UNQUOTED).setCharset(ISO_8859_1).setUseAlways(true).build();
 
     private final RuleContext ruleContext;
 
@@ -457,6 +457,11 @@ public final class JavaHeaderCompileAction extends SpawnAction {
                 ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS,
                 outputDepsProto.getExecPathString());
       }
+      executionInfo = ImmutableMap.<String, String>builder()
+          .putAll(executionInfo)
+          .putAll(ExecutionRequirements.WORKER_MODE_ENABLED)
+          .putAll(ExecutionRequirements.WORKER_MULTIPLEX_MODE_ENABLED)
+          .build();
       if (useDirectClasspath) {
         NestedSet<Artifact> classpath;
         if (!directJars.isEmpty() || classpathEntries.isEmpty()) {
@@ -485,7 +490,7 @@ public final class JavaHeaderCompileAction extends SpawnAction {
         ruleContext.registerAction(
             new JavaHeaderCompileAction(
                 /* owner= */ ruleContext.getActionOwner(),
-                /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+                /* tools= */ headerCompiler.tool().getFilesToRun(),
                 /* inputs= */ allInputs,
                 /* outputs= */ outputs.build(),
                 /* resourceSetOrBuilder= */ AbstractAction.DEFAULT_RESOURCE_SET,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
@@ -68,6 +68,10 @@ public class JavaToolchain implements RuleConfiguredTargetFactory {
         ruleContext.attributes().get("javac_supports_multiplex_workers", Type.BOOLEAN);
     boolean javacSupportsWorkerCancellation =
         ruleContext.attributes().get("javac_supports_worker_cancellation", Type.BOOLEAN);
+    boolean headerCompilerSupportsWorkers =
+        ruleContext.attributes().get("header_compiler_supports_workers", Type.BOOLEAN);
+    boolean headerCompilerSupportsMultiplexWorkers =
+        ruleContext.attributes().get("header_compiler_supports_multiplex_workers", Type.BOOLEAN);
     ImmutableSet<String> headerCompilerBuiltinProcessors =
         ImmutableSet.copyOf(
             ruleContext.attributes().get("header_compiler_builtin_processors", Type.STRING_LIST));
@@ -168,6 +172,8 @@ public class JavaToolchain implements RuleConfiguredTargetFactory {
             javacSupportsWorkers,
             javacSupportsMultiplexWorkers,
             javacSupportsWorkerCancellation,
+            headerCompilerSupportsWorkers,
+            headerCompilerSupportsMultiplexWorkers,
             bootclasspath,
             tools,
             javabuilder,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainProvider.java
@@ -97,6 +97,8 @@ public final class JavaToolchainProvider extends NativeInfo
       boolean javacSupportsWorkers,
       boolean javacSupportsMultiplexWorkers,
       boolean javacSupportsWorkerCancellation,
+      boolean headerCompilerSupportsWorkers,
+      boolean headerCompilerSupportsMultiplexWorkers,
       BootClassPathInfo bootclasspath,
       NestedSet<Artifact> tools,
       JavaToolchainTool javaBuilder,
@@ -149,6 +151,8 @@ public final class JavaToolchainProvider extends NativeInfo
         javacSupportsWorkers,
         javacSupportsMultiplexWorkers,
         javacSupportsWorkerCancellation,
+        headerCompilerSupportsWorkers,
+        headerCompilerSupportsMultiplexWorkers,
         packageConfiguration,
         jacocoRunner,
         proguardAllowlister,
@@ -182,6 +186,8 @@ public final class JavaToolchainProvider extends NativeInfo
   private final boolean javacSupportsWorkers;
   private final boolean javacSupportsMultiplexWorkers;
   private final boolean javacSupportsWorkerCancellation;
+  private final boolean headerCompilerSupportsWorkers;
+  private final boolean headerCompilerSupportsMultiplexWorkers;
   private final ImmutableList<JavaPackageConfigurationProvider> packageConfiguration;
   private final FilesToRunProvider jacocoRunner;
   private final FilesToRunProvider proguardAllowlister;
@@ -215,6 +221,8 @@ public final class JavaToolchainProvider extends NativeInfo
       boolean javacSupportsWorkers,
       boolean javacSupportsMultiplexWorkers,
       boolean javacSupportsWorkerCancellation,
+      boolean headerCompilerSupportsWorkers,
+      boolean headerCompilerSupportsMultiplexWorkers,
       ImmutableList<JavaPackageConfigurationProvider> packageConfiguration,
       FilesToRunProvider jacocoRunner,
       FilesToRunProvider proguardAllowlister,
@@ -247,6 +255,8 @@ public final class JavaToolchainProvider extends NativeInfo
     this.javacSupportsWorkers = javacSupportsWorkers;
     this.javacSupportsMultiplexWorkers = javacSupportsMultiplexWorkers;
     this.javacSupportsWorkerCancellation = javacSupportsWorkerCancellation;
+    this.headerCompilerSupportsWorkers = headerCompilerSupportsWorkers;
+    this.headerCompilerSupportsMultiplexWorkers = headerCompilerSupportsMultiplexWorkers;
     this.packageConfiguration = packageConfiguration;
     this.jacocoRunner = jacocoRunner;
     this.proguardAllowlister = proguardAllowlister;
@@ -417,6 +427,16 @@ public final class JavaToolchainProvider extends NativeInfo
   /** Returns whether JavaBuilders supports running persistent workers in multiplex mode */
   public boolean getJavacSupportsMultiplexWorkers() {
     return javacSupportsMultiplexWorkers;
+  }
+
+  /** Returns whether JavaHeaderCompiler supports running as a persistent worker or not. */
+  public boolean getHeaderCompilerSupportsWorkers() {
+    return headerCompilerSupportsWorkers;
+  }
+
+  /** Returns whether JavaHeaderCompiler supports running persistent workers in multiplex mode */
+  public boolean getHeaderCompilerSupportsMultiplexWorkers() {
+    return headerCompilerSupportsMultiplexWorkers;
   }
 
   /** Returns whether JavaBuilders supports running persistent workers with cancellation */

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
@@ -129,6 +129,14 @@ public final class JavaToolchainRule<C extends JavaToolchain> implements RuleDef
         True if JavaBuilder supports cancellation of persistent workers, false if it doesn't.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("javac_supports_worker_cancellation", BOOLEAN).value(true))
+        /* <!-- #BLAZE_RULE(java_toolchain).ATTRIBUTE(header_compiler_supports_workers) -->
+        True if JavaHeaderCompiler supports running as a persistent worker, false if it doesn't.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("header_compiler_supports_workers", BOOLEAN).value(false))
+        /* <!-- #BLAZE_RULE(java_toolchain).ATTRIBUTE(header_compiler_supports_multiplex_workers) -->
+        True if JavaHeaderCompiler supports running as a multiplex persistent worker, false if it doesn't.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("header_compiler_supports_multiplex_workers", BOOLEAN).value(false))
         /* <!-- #BLAZE_RULE(java_toolchain).ATTRIBUTE(tools) -->
         Labels of tools available for label-expansion in jvm_opts.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */


### PR DESCRIPTION
Implement a wrapper to support Turbine worker mode.

But how to publish java_tools?

not using worker:
![image](https://github.com/bazelbuild/bazel/assets/10076965/c490e558-e838-4c3a-95e2-3ee4bd16739d)
using worker:
![image](https://github.com/bazelbuild/bazel/assets/10076965/9d2ec22e-ab9a-4ad6-bd58-cbe8a713b5b3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running the Java header compiler as a persistent worker, including multiplex worker mode, to improve build performance.
  - Introduced new configuration options to control worker support for the header compiler.

- **Bug Fixes**
  - Improved execution information handling for Java header compilation, ensuring correct worker mode settings are applied.

- **Chores**
  - Updated internal build targets and toolchain definitions to support new worker features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->